### PR TITLE
add NOWAIT falg in smp_call path to avoid sleep

### DIFF
--- a/simple-pt.c
+++ b/simple-pt.c
@@ -594,7 +594,7 @@ static int simple_pt_buffer_init(int cpu)
 	/* allocate buffer */
 	pt_buffer = per_cpu(pt_buffer_cpu, cpu);
 	if (!pt_buffer) {
-		pt_buffer = __get_free_pages(GFP_KERNEL|__GFP_NOWARN|__GFP_ZERO, pt_buffer_order);
+		pt_buffer = __get_free_pages(GFP_NOWAIT |GFP_KERNEL|__GFP_NOWARN|__GFP_ZERO, pt_buffer_order);
 		if (!pt_buffer) {
 			pr_err("cpu %d, Cannot allocate %ld KB buffer\n", cpu,
 					(PAGE_SIZE << pt_buffer_order) / 1024);
@@ -622,7 +622,7 @@ static int simple_pt_buffer_init(int cpu)
 				(pt_buffer_order << TOPA_SIZE_SHIFT);
 			for (; n < pt_num_buffers; n++) {
 				void *buf = (void *)__get_free_pages(
-					GFP_KERNEL|__GFP_NOWARN|__GFP_ZERO,
+					GFP_NOWAIT| GFP_KERNEL|__GFP_NOWARN|__GFP_ZERO,
 					pt_buffer_order);
 				if (!buf) {
 					pr_warn("Cannot allocate %d'th PT buffer\n", n);


### PR DESCRIPTION
without this patch
load and unload module for several times, will encounter following calltrace

[ 1045.726726] BUG: scheduling while atomic: swapper/0/0/0x10010000
[ 1045.726787] Call Trace:
 dump_stack+0x19/0x1b
 __schedule_bug+0x4d/0x5b
 __schedule+0xa60/0xac0
 __cond_resched+0x26/0x30
 _cond_resched+0x3a/0x50
 __alloc_pages_nodemask+0x325/0xc40
 ? native_sched_clock+0x35/0x80
 ? sched_clock+0x9/0x10
 ? local_clock+0x25/0x30
 ? log_store+0x178/0x200
 ? down_trylock+0x2d/0x40
 ? console_trylock+0x19/0x70
 alloc_pages_current+0xa9/0x170
 __get_free_pages+0xe/0x50
 spt_cpu_startup+0x94/0x230 [simple_pt]