### PR TITLE
fix wrong increment in TSC packet

### DIFF
--- a/fastdecode.c
+++ b/fastdecode.c
@@ -294,7 +294,7 @@ void decode_buffer(unsigned char *map, size_t len)
 			}
 
 			if (*p == 0x19 && LEFT(8)) {  /* TSC */
-				p++;
+				p += 8;
 				printf("tsc\t%llu\n", get_val(&p, 7));
 				continue;
 			}


### PR DESCRIPTION
TSC packet has a length of 8 while the increment is 1.