### PR TITLE
simple-pt: Mask out the PCID in the cr3

### DIFF
--- a/simple-pt.c
+++ b/simple-pt.c
@@ -801,7 +801,7 @@ static u64 retrieve_cr3(void)
 {
 	u64 cr3;
 	asm volatile("mov %%cr3,%0" : "=r" (cr3));
-	return cr3;
+	return cr3 & ~0xfff; // mask out the PCID
 }
 
 static void probe_sched_process_exec(void *arg,


### PR DESCRIPTION
I use Ubuntu 18.04 (Linux 4.15) and I found that even if I boot the kernel with nopti option, the kernel set the PCID in the cr3. As a result, writing MSR_IA32_CR3_MATCH failed. This patch masks out the PCID. 

Related: #20.
