### PR TITLE
Enable Targetting CR3 Filtering on Specific Process

### DIFF
--- a/simple-pt.c
+++ b/simple-pt.c
@@ -470,7 +470,7 @@ static int start_pt(void)
 		val |= CTL_USER;
 	if (cr3_filter && has_cr3_match) {
 		if(cr3_filter > 1) {
-			val_cr3 = pid_to_cr3(cr3_filter);
+			val_cr3 = pid_to_cr3(cr3_filter) & ~0xFFF;
 			set_cr3 = true;
 			comm_filter[0] = '\0';	// Do not re-target on exec()
 		}

--- a/simple-pt.c
+++ b/simple-pt.c
@@ -410,7 +410,7 @@ static void init_mask_ptrs(void)
 }
 
 // https://carteryagemann.com/pid-to-cr3.html
-u64 pid_to_cr3(int pid) {
+static u64 pid_to_cr3(int pid) {
 	struct task_struct *task;
 	struct mm_struct *mm;
 	void *cr3_virt;
@@ -422,8 +422,10 @@ u64 pid_to_cr3(int pid) {
 
 	// mm can be NULL in some rare cases (e.g. kthreads)
 	// when this happens, we should check active_mm
-	if(mm == NULL)	mm = task->active_mm;
-	if(mm == NULL)	return 0; // this shouldn't happen, but just in case
+	if(mm == NULL) {
+		mm = task->active_mm;
+		if(mm == NULL)	return 0; // this shouldn't happen, but just in case
+	}
 
 	cr3_virt = (void*)mm->pgd;
 	cr3_phys = virt_to_phys(cr3_virt);

--- a/simple-pt.c
+++ b/simple-pt.c
@@ -477,9 +477,12 @@ static int start_pt(void)
 		if(cr3_filter > 1) {
 			u64 cr3 = pid_to_cr3(cr3_filter) & ~CR3_PCID_MASK;
 #ifdef CONFIG_PAGE_TABLE_ISOLATION
-			if(IS_ENABLED(CONFIG_PAGE_TABLE_ISOLATION)) {
-				if(user && static_cpu_has(X86_FEATURE_PTI)) {
+			if(IS_ENABLED(CONFIG_PAGE_TABLE_ISOLATION) && static_cpu_has(X86_FEATURE_PTI)) {
+				if(user) {
 					cr3 |= 1 << PAGE_SHIFT;
+					if(kernel) {
+						pr_warn("Cannot trace kernel along with user space using CR3 filter in PTI-enabled kernel.\n");
+					}
 				}
 			}
 #endif

--- a/simple-pt.c
+++ b/simple-pt.c
@@ -476,11 +476,13 @@ static int start_pt(void)
 	if (cr3_filter && has_cr3_match) {
 		if(cr3_filter > 1) {
 			u64 cr3 = pid_to_cr3(cr3_filter) & ~CR3_PCID_MASK;
+#ifdef CONFIG_PAGE_TABLE_ISOLATION
 			if(IS_ENABLED(CONFIG_PAGE_TABLE_ISOLATION)) {
 				if(user && static_cpu_has(X86_FEATURE_PTI)) {
 					cr3 |= 1 << PAGE_SHIFT;
 				}
 			}
+#endif
 			set_cr3_filter0(cr3);
 			comm_filter[0] = '\0';	// Do not re-target on exec()
 		}


### PR DESCRIPTION
This patch allows to target the CR3 filter on a specific process. It interprets values written to `cr3_filter` that are larger than 1 (>1) as PID, determines their corresponding CR3 value and configures CR3_MATCH with it. At the time of initialization it disarms potentially `comm_filter` left overs to avoid being replaced by matching starting programs.