### PR TITLE
simple-pt: Fix build error

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -1,6 +1,10 @@
 
 #include <linux/version.h>
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(5,6,0)
+#define  __symbol_get kallsyms_lookup_name
+#endif
+
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
 static struct tracepoint *exec_tp;
 
@@ -8,7 +12,7 @@ static inline int compat_register_trace_sched_process_exec(void (*probe)(void *,
 						void *arg)
 {
 	/* Workaround for newer kernels which use non exported symbols */
-	exec_tp = (struct tracepoint *)kallsyms_lookup_name("__tracepoint_sched_process_exec");
+	exec_tp = (struct tracepoint *)__symbol_get("__tracepoint_sched_process_exec");
 	if (!exec_tp)
 		return -EIO;
 	return tracepoint_probe_register(exec_tp, (void *)probe, NULL);
@@ -49,8 +53,8 @@ static void fix_tracepoints(void)
 	int (*trace_module_notify_sym)(struct notifier_block * nb,
 		    unsigned long val, struct module * mod);
 
-	trace_module_notify_sym = (void*)kallsyms_lookup_name("trace_module_notify");
-	tracepoint_module_notify_sym = (void*)kallsyms_lookup_name("tracepoint_module_notify");
+	trace_module_notify_sym = (void*)__symbol_get("trace_module_notify");
+	tracepoint_module_notify_sym = (void*)__symbol_get("tracepoint_module_notify");
 
 	if (trace_module_notify_sym && tracepoint_module_notify_sym) {
 		unsigned old_taint = THIS_MODULE->taints;

--- a/simple-pt.c
+++ b/simple-pt.c
@@ -167,7 +167,7 @@ static int symbol_set(const char *val, const struct kernel_param *kp)
 				return -EIO;
 			}
 		}
-		addr = kallsyms_lookup_name(sym);
+		addr = (unsigned long)__symbol_get(sym);
 		if (!addr)
 			pr_err("Lookup of '%s' symbol failed\n", sym);
 		if (addr && offset)
@@ -600,7 +600,7 @@ static void do_enumerate_all(void)
 	/* XXX, better way? */
 	rwlock_t *my_tasklist_lock = (rwlock_t *)tasklist_lock_ptr;
 	if (!my_tasklist_lock)
-		my_tasklist_lock = (rwlock_t *)kallsyms_lookup_name("tasklist_lock");
+		my_tasklist_lock = (rwlock_t *)__symbol_get("tasklist_lock");
 	if (!my_tasklist_lock) {
 		pr_err("Cannot find tasklist_lock. CONFIG_KALLSYMS_ALL disabled?\n");
 		pr_err("Specify tasklist_lock_ptr parameter at module load\n");


### PR DESCRIPTION
From linux v5.7-rc1, it unexports kallsyms_lookup_name(),so use
__symbol_get() for linux version >= v5.7-rc1 instead and keep
kallsyms_lookup_name for the old linux kernel.

Signed-off-by: Zhengjun Xing <zhengjun.xing@linux.intel.com>