### PR TITLE
Fix build error with kernel above 5.14

### DIFF
--- a/simple-pt.c
+++ b/simple-pt.c
@@ -66,6 +66,11 @@
 #define CREATE_TRACE_POINTS
 #include "pttp.h"
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#include <linux/panic_notifier.h>
+#endif
+
 #include "compat.h"
 #include "simple-pt.h"
 


### PR DESCRIPTION
From kernel 5.14, `panic_notifier.h` was moved out from `kernel.h`. Thus using `panic_notifier_list` needs `panic_notifier.h` included.
I use `KERNEL_VERSION_CODE` in `simple-pt.c` to distinguish newer kernel without breaking older ones.